### PR TITLE
assoc-in

### DIFF
--- a/src/speculative/core.cljc
+++ b/src/speculative/core.cljc
@@ -268,6 +268,26 @@
   :fn (fn [{:keys [args ret]}]
         (= (key args) (key ret))))
 
+;; 6152
+(s/def ::assoc-in-args
+  (s/with-gen (s/cat :map (s/nilable ::ss/associative)
+                     :keys (s/coll-of ::ss/any :min-elements 1 :kind sequential?)
+                     :val ::ss/any)
+              #(gen/one-of
+                 [(gen/tuple (s/gen map?)
+                             (gen/not-empty (gen/vector (gen/any)))
+                             (gen/any))
+                  (gen/bind (gen/vector (gen/any))
+                            (fn [v]
+                              (gen/tuple (gen/return v)
+                                         (gen/bind (gen/choose 0 (max 0 (dec (count v))))
+                                                   (fn [i] (gen/return [i])))
+                                         (gen/any))))])))
+
+(s/fdef clojure.core/assoc-in
+  :args ::assoc-in-args
+  :ret ::ss/associative)
+
 ;; 6536
 (s/fdef clojure.core/fnil
   :args (s/cat :f ::ss/ifn :xs (s/+ ::ss/any))

--- a/src/speculative/instrument.cljc
+++ b/src/speculative/instrument.cljc
@@ -62,6 +62,7 @@
     re-find
     subs
     interpose
+    assoc-in
     fnil
     reduce
     into

--- a/test/speculative/core_test.cljc
+++ b/test/speculative/core_test.cljc
@@ -102,8 +102,8 @@
   (is (= 0 (check-call `apply [+ nil])))
   #?(:clj (with-instrumentation `apply
             (is (caught? `apply (apply + 1 2 3 4))))
-     :cljs nil ;; maximum call stack exceeded
-     ))
+     :cljs nil)) ;; maximum call stack exceeded
+
 
 ;; 783
 (deftest =-test
@@ -429,6 +429,22 @@
       (is (caught? `interpose (interpose))))
     (testing "non-coll arg"
       (is (caught? `interpose (interpose 0 0))))))
+
+;; 6152
+(deftest assoc-in-test
+  (is (check-call `assoc-in [[] [0] :val]))
+  (is (check-call `assoc-in [[] '(0) :val]))
+  (is (check-call `assoc-in [{} [:a] :val]))
+  (is (check-call `assoc-in [nil [:a] :val]))
+  (check `assoc-in)
+  (with-instrumentation `assoc-in
+                        (testing "first arg not an associative/nil"
+                          (is (caught? `assoc-in (assoc-in '() [0] :val))))
+                        (testing "Provided ks not a sequential"
+                          (is (caught? `assoc-in (assoc-in [] 0 :val)))))
+  (testing "Index out of bounds" (is (thrown? #?(:clj java.lang.IndexOutOfBoundsException
+                                                 :cljs js/Error)
+                                              (check-call `assoc-in [[] [1] :val])))))
 
 ;; 6536
 (deftest fnil-test

--- a/test/speculative/instrument_test.cljc
+++ b/test/speculative/instrument_test.cljc
@@ -10,7 +10,7 @@
 
 (deftest instrument-test
   (testing "speculative specs should be instrumentable and unstrumentable"
-    (let [spec-count #?(:clj 58 :cljs 54)
+    (let [spec-count #?(:clj 59 :cljs 55)
           instrumented (instrument/instrument)
           unstrumented (instrument/unstrument)]
       (is (= spec-count (count instrumented)))


### PR DESCRIPTION
Generative testing would need specs using multimethod on `type` I think.
In case of a `vector` or another non-sparse associative only integers `(<= 0 % (count coll))` is valid.
I have not implemented that, is that in the scope for speculative?